### PR TITLE
Correção no MdPetIntPrazoRN.php para pegar corretamente Feriado indic…

### DIFF
--- a/sei/web/modulos/peticionamento/rn/MdPetIntPrazoRN.php
+++ b/sei/web/modulos/peticionamento/rn/MdPetIntPrazoRN.php
@@ -232,7 +232,7 @@
             $objFeriadoDTO->retDtaFeriado();
             $objFeriadoDTO->retStrDescricao();
 
-            if($numIdOrgao != ''){
+            if(is_numeric($numIdOrgao)){
                 $objFeriadoDTO->adicionarCriterio(array('IdOrgao','IdOrgao'),
                 array(InfraDTO::$OPER_IGUAL,InfraDTO::$OPER_IGUAL),
                 array(null,$numIdOrgao),


### PR DESCRIPTION
Correção no MdPetIntPrazoRN.php para pegar corretamente Feriado indicado na Administração do SEI como sendo Feriado de apenas um órgão.

Com o cadastro na Administração de Feriado aplicável apenas a um órgão, o Feriado não era reconhecimento no âmbito do Cumprimento de Intimação Eletrônica, seja pela consulta direta ou pelo agendamento CumprirPorDecursoPrazoTacito.