### PR TITLE
chore: adiciona prefixo com nome do módulo nas validações

### DIFF
--- a/sei/web/modulos/peticionamento/PeticionamentoIntegracao.php
+++ b/sei/web/modulos/peticionamento/PeticionamentoIntegracao.php
@@ -19,6 +19,7 @@ class PeticionamentoIntegracao extends SeiIntegracao
     public static $INTIMACAO_CUMPRIDA_PARCIAL = 1;
     public static $INTIMACAO_CUMPRIDA = 2;
     public static $INTIMACAO_NEGADA = 3;
+    private $strNomeModulo = $this->getNome();
 
     public function __construct()
     {
@@ -1682,8 +1683,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
             if ($objReciboPetDTO) {
                 $numRecibo = $objReciboPetDTO->getStrNumeroProcessoFormatadoDoc();
             }
-
-            $msg = 'Não é permitido cancelar este documento, pois ele é oriundo de Peticionamento Eletrônico, conforme Recibo Eletrônico de Protocolo SEI nº ' . $numRecibo . '.';
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: Não é permitido cancelar este documento, pois ele é oriundo de Peticionamento Eletrônico, conforme Recibo Eletrônico de Protocolo SEI nº $numRecibo .";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -1701,6 +1702,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
         if ($total > 0) {
 
             $msg = 'Não é permitido cancelar este documento, pois ele faz parte de Intimação Eletrônica.';
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -1712,6 +1715,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         // condição para saber  o documento está sendo utilizado em um indisponibilidade
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
             return null;
@@ -1741,8 +1746,10 @@ class PeticionamentoIntegracao extends SeiIntegracao
         $totalDocDisponivel = $rnDocDisponivel->contar($dtoDocDisponivel);
 
         if ($total > 0 || $totalDocDisponivel > 0) {
-
             $msg = 'Não é permitido mover este documento, pois ele faz parte de Intimação Eletrônica.';
+            
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -3175,8 +3182,9 @@ class PeticionamentoIntegracao extends SeiIntegracao
                     $docTipoIntegral = $objMdPetRegrasGeraisRN->verificarDocumentoTipoIntegral($idAcessoExt);
 
                     if (!$docTipoIntegral) {
+                        $strNomeModulo = $this->getNome();
                         $objInfraException = new InfraException();
-                        $objInfraException->adicionarValidacao('Não é permitido cancelar a disponibilização para esse usuário, pois existem vinculos no módulo Peticionamento e Intimação Eletrônicos.');
+                        $objInfraException->adicionarValidacao("$strNomeModulo: Não é permitido cancelar a disponibilização para esse usuário, pois existem vinculos no módulo Peticionamento e Intimação Eletrônicos.");
                         $objInfraException->lancarValidacoes();
                         return null;
                     } else {
@@ -3226,7 +3234,9 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         if ($isRespIntPeriodo) {
             $msg = 'Não é permitido anexar este processo, pois o mesmo possui Intimação Eletrônica ainda em curso.';
-
+            
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -3249,7 +3259,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
         if ($isRespIntPeriodo) {
             $msg = 'Não é permitido sobrestar este processo, pois o mesmo possui Intimação Eletrônica ainda em curso.';
 
-
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -3272,7 +3283,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
         if ($isRespIntPeriodo) {
             $msg = 'Não é permitido Bloquear este processo, pois o mesmo possui Intimação Eletrônica ainda em curso.';
 
-
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -3300,7 +3312,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
             } else {
                 $msg = 'Não é permitido desanexar este processo, pois o mesmo é Documento Disponível de Intimação Eletrônica neste processo.';
             }
-
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->adicionarValidacao($msg);
             $objInfraException->lancarValidacoes();
@@ -3328,6 +3341,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
         $mdPetRegrasGeraisRN = new MdPetRegrasGeraisRN();
         $msg = $mdPetRegrasGeraisRN->verificarExistenciaUnidade(array($arrObjUnidadeAPI, 'desativar'));
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
@@ -3343,6 +3358,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         //verifica se existe um processo sendo utilizado
         if ($msg != "") {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
@@ -3358,11 +3375,15 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         // condição para saber se existe um documento sendo usado
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
             $msg = $mdPetRegrasGeraisRN->verificarParametroTipoDocumento(array($arrObjSerieAPI, 'desativar'));
             if ($msg != '') {
+                $strNomeModulo = $this->getNome();
+                $msg = "$strNomeModulo: $msg";
                 $objInfraException = new InfraException();
                 $objInfraException->lancarValidacao($msg);
             } else {
@@ -3375,6 +3396,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
 	{
         $msg = (new MdPetRegrasGeraisRN())->verificarExcluirDesativarUsuarioExterno([$arrObjUsuarioAPI, 'excluir']);
 		if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
 			(new InfraException())->lancarValidacao($msg);
 		}
 	}
@@ -3396,6 +3419,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
         $mdPetRegrasGeraisRN = new MdPetRegrasGeraisRN();
         $msg = $mdPetRegrasGeraisRN->verificarExistenciaUnidade(array($arrObjUnidadeAPI, 'excluir'));
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
@@ -3411,6 +3436,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         //verifica se existe um processo sendo utilizado
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
@@ -3429,11 +3456,15 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         // condição para saber se existe um documento sendo usado
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
             $msg = $mdPetRegrasGeraisRN->verificarParametroTipoDocumento(array($arrObjSerieAPI, 'excluir'));
             if ($msg != '') {
+                $strNomeModulo = $this->getNome();
+                $msg = "$strNomeModulo: $msg";
                 $objInfraException = new InfraException();
                 $objInfraException->lancarValidacao($msg);
             } else {
@@ -3449,6 +3480,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
 
         // condição para saber  o documento está sendo utilizado em um indisponibilidade
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             $objInfraException = new InfraException();
             $objInfraException->lancarValidacao($msg);
         } else {
@@ -3460,6 +3493,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
     {
         $msg = (new MdPetRegrasGeraisRN())->verificarExcluirDesativarContato([$arrObjContatoAPI, 'excluir']);
         if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             (new InfraException())->lancarValidacao($msg);
         }
     }
@@ -3468,6 +3503,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
     {
         $msg = (new MdPetRegrasGeraisRN())->verificarExcluirDesativarContato([$arrObjContatoAPI, 'desativar']);
 		if ($msg != '') {
+            $strNomeModulo = $this->getNome();
+            $msg = "$strNomeModulo: $msg";
             (new InfraException())->lancarValidacao($msg);
 		}
     }
@@ -3644,7 +3681,8 @@ class PeticionamentoIntegracao extends SeiIntegracao
             }
 
             if(!empty($msgVinc)){
-                $preMsg = 'Não é permitido alterar Contato que possua registro de Vinculação ou Procuração Eletrônica ativa.\n\n';
+                $strNomeModulo = $this->getNome();
+                $preMsg = "$strNomeModulo: Não é permitido alterar Contato que possua registro de Vinculação ou Procuração Eletrônica ativa.\n\n";
                 $msg .= ''. $objContatoAPI->getNome() . ' ainda possui as seguintes Vinculações ou Procurações ativas:\n\n'.$msgVinc.'\n';
                 if(!empty($msg)){ (new InfraException())->lancarValidacao(substr($preMsg.$msg, 0, -2)); }
             }

--- a/sei/web/modulos/peticionamento/PeticionamentoIntegracao.php
+++ b/sei/web/modulos/peticionamento/PeticionamentoIntegracao.php
@@ -19,7 +19,6 @@ class PeticionamentoIntegracao extends SeiIntegracao
     public static $INTIMACAO_CUMPRIDA_PARCIAL = 1;
     public static $INTIMACAO_CUMPRIDA = 2;
     public static $INTIMACAO_NEGADA = 3;
-    private $strNomeModulo = $this->getNome();
 
     public function __construct()
     {


### PR DESCRIPTION
Os órgãos abrem chamado para o PEN mas não sabem que a mensagem é do módulo do peticionamento. A sugestão é deixar claro a origem da mensagem.