### PR TITLE
fix: adicionado validação da array do petIntegracaoParametro, caso null

### DIFF
--- a/sei/web/modulos/peticionamento/rn/MdPetIntegracaoRN.php
+++ b/sei/web/modulos/peticionamento/rn/MdPetIntegracaoRN.php
@@ -234,7 +234,13 @@ class MdPetIntegracaoRN extends InfraRN
 
         $objMdPetIntegParametroDTO->retTodos();
         $objMdPetIntegParametroDTO->setStrTpParametro('P');
-        $objMdPetIntegParametroDTO->setNumIdMdPetIntegracao($arrObjMdPetIntegracaoDTO->getNumIdMdPetIntegracao());
+
+        if($arrObjMdPetIntegracaoDTO){
+            $objMdPetIntegParametroDTO->setNumIdMdPetIntegracao($arrObjMdPetIntegracaoDTO->getNumIdMdPetIntegracao());
+        } else {
+            $objMdPetIntegParametroDTO->setNumIdMdPetIntegracao($objMdPetIntegParametroDTO->setNumIdMdPetIntegracao($objMdPetIntegracao->getNumIdMdPetIntegracao()));
+        }
+        
         $arrObjMdPetIntegParametroDTO = $mdPetIntegParametroRN->listar($objMdPetIntegParametroDTO);
 
         if ($arrObjMdPetIntegParametroDTO) {


### PR DESCRIPTION
Caso a $arrObjMdPetIntegracaoDTO seja nula, seta os dados usando o objeto anterior. 
Mantém no if o código anterior para caso consiga usar a $arrObjMdPetIntegracaoDTO sem problemas.

Na forma anterior, caso a $arrObjMdPetIntegracaoDTO fosse nula, acontecia um erro genérico e os dados da empresa que chegaram com a integração não eram preenchidos automaticamente (no caso exclusivo de sucesso da validação responsável legal <-> empresa consultada).