### PR TITLE
erro javascript removeAttribute bloqueava botao segundo upload de arq…

### DIFF
--- a/sei/web/modulos/peticionamento/md_pet_usu_ext_cadastro_js.php
+++ b/sei/web/modulos/peticionamento/md_pet_usu_ext_cadastro_js.php
@@ -514,8 +514,10 @@ $strLinkAjaxChecarConteudoDocumento = SessaoSEIExterna::getInstance()->assinarLi
         //se nao for o "Principal", resetar a seleçao da combo "Tipo"
         if (numero != '1') {
             document.getElementById('tipoDocumento' + complemento).options[0].selected = 'selected';
-            document.querySelector('select[name="hipoteseLegal' + numero + '"]').removeAttribute("disabled");
-            document.querySelector('select[name="nivelAcesso' + numero + '"]').removeAttribute("disabled");
+			const el = document.querySelector('select[name="hipoteseLegal${numero}"]');
+			if (el) el.removeAttribute("disabled");   			            
+			const e2 = document.querySelector('select[name="nivelAcesso${numero}"]');
+			if (e2) el.removeAttribute("disabled");
         }
 
         cbTipoConferencia.options[0].selected = 'selected';


### PR DESCRIPTION
Após adicionar um arquivo para upload e enviar, o botão não deixa adicionar outro, dá erro javascript e acaba bloqueando o botão. Tenta dar removeAttribute num atributo que não existe.